### PR TITLE
Add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+MIT/X11 License:
+
+Copyright © 2011-2012 Heroku, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,6 @@
-# Heroku buildpack: Clojure / Boot
+# Heroku buildpack: Clojure / Boot / Org-Babel
 
-This is a Heroku buildpack for use with Clojure projects that use Boot.
+This is a Heroku buildpack for use with Clojure projects that use Boot
+and are written in a literate programming style with Org-Babel.
 
-First make sure you have at LEAST heroku gem version 2.11.0+
-
-
-## Usage
-
-See the [Clojure buildpack](https://github.com/heroku/heroku-buildpack-clojure) for details.
-
+Based on https://github.com/pandeiro/heroku-buildpack-boot

--- a/README.md
+++ b/README.md
@@ -4,3 +4,14 @@ This is a Heroku buildpack for use with Clojure projects that use Boot
 and are written in a literate programming style with Org-Babel.
 
 Based on https://github.com/pandeiro/heroku-buildpack-boot
+
+## Work in progress
+
+This is not working yet. I did experiment with multiple buildpacks via
+https://github.com/ddollar/heroku-buildpack-multi and installing emacs via apt
+through https://github.com/ddollar/heroku-buildpack-apt.
+Emacs got installed, but binary is not found by other buildpacks then:
+https://github.com/ddollar/heroku-buildpack-multi/issues/28
+
+An alternative could be to use a prebuilt emacs binary like it's done in
+https://github.com/technomancy/heroku-buildpack-emacs

--- a/bin/compile
+++ b/bin/compile
@@ -28,9 +28,20 @@ export_env_dir() {
 
 export_env_dir $ENV_DIR
 
+# Install Emacs24
+echo "Downloading Emacs 24 pretest from github..." | indent
+curl -L -s -o $1/emacs.tar.gz https://github.com/downloads/nicferrier/heroku-buildpack-emacs/static-emacs.tar.gz
+echo "...done" | indent
+
+# Install Org-Mode
+mkdir ~/elisp
+git clone git://orgmode.org/org-mode.git ~/elisp/org-mode
+pushd ~/elisp/org-mode && make autoloads
+popd
+
 # tangle org files
-if [ ! -r $BUILD_DIR/$ORG_BUILD_FILE ]; then
-    echo " !   No ORG_BUILD_FILE found; aborting"
+if [ ! -r "$ORG_BUILD_FILE" ]; then
+    echo " !   No ORG_BUILD_FILE set; aborting"
     exit 1
 fi
 echo "-----> Tangling org files..."

--- a/bin/compile
+++ b/bin/compile
@@ -28,6 +28,15 @@ export_env_dir() {
 
 export_env_dir $ENV_DIR
 
+# tangle org files
+if [ ! -r $BUILD_DIR/$ORG_BUILD_FILE ]; then
+    echo " !   No ORG_BUILD_FILE found; aborting"
+    exit 1
+fi
+echo "-----> Tangling org files..."
+$BUILD_DIR/org/tangle.sh $BUILD_DIR/$ORG_BUILD_FILE
+echo "       ...done"
+
 # Load common JVM functionality from https://github.com/heroku/heroku-buildpack-jvm-common
 JVM_COMMON_BUILDPACK=${JVM_COMMON_BUILDPACK:-https://codon-buildpacks.s3.amazonaws.com/buildpacks/heroku/jvm-common.tgz}
 mkdir -p /tmp/jvm-common
@@ -107,4 +116,3 @@ fi
 rm -rf $CACHE_STORE_DIR
 mkdir -p $(dirname $CACHE_STORE_DIR)
 cp -r $CACHE_TARGET_DIR $CACHE_STORE_DIR
-

--- a/bin/detect
+++ b/bin/detect
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-if [ -f $1/build.boot ]; then
-  echo "BootClojure"
+if [ -f $1/org/tangle.sh ]; then
+  echo "BootClojureOrgBabel"
   exit 0
 else
   exit 1


### PR DESCRIPTION
The buildpack does not have a license yet and I could not find a license in the upstream of forks. Would be great if we could add MIT license as I would like to create a buildpack based on this one for Clojure/Boot/Org-Babel.
